### PR TITLE
fix: capture ring buffer overflow in ingest_prefill to prevent silent KV data loss

### DIFF
--- a/tests/test_ingest_prefill_overflow.py
+++ b/tests/test_ingest_prefill_overflow.py
@@ -1,0 +1,78 @@
+"""Reproduction for silent KV data loss in ``KVCaptureEngine.ingest_prefill``.
+
+``RingBuffer.write`` returns overflow tokens when it is full; ``ingest_prefill``
+must forward that overflow to the store (mirroring ``ingest_decode``) or tokens
+are silently dropped. These tests exercise the real code path -- they do not
+mock ``ingest_prefill`` or ``ring.write`` -- and assert no token is lost across
+chunked prefill calls.
+
+The module is loaded with ``importlib.util`` because the ``turboquant`` package
+``__init__`` imports scipy (an optional dep), while ``capture.py`` itself only
+needs torch.
+"""
+import importlib.util
+import os
+
+import torch
+
+
+def _load_capture_module():
+    here = os.path.dirname(__file__)
+    repo_root = os.path.abspath(os.path.join(here, ".."))
+    capture_path = os.path.join(repo_root, "turboquant", "capture.py")
+    spec = importlib.util.spec_from_file_location("tq_capture", capture_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+capture = _load_capture_module()
+KVCaptureEngine = capture.KVCaptureEngine
+
+
+class MockStore:
+    """Minimal stand-in for ``CompressedKVStore``; tracks appended tokens."""
+
+    def __init__(self, num_kv_heads, head_dim, device):
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = head_dim
+        self.device = device
+        self._num_tokens = 0
+
+    @property
+    def num_tokens(self):
+        return self._num_tokens
+
+    def append_chunk(self, key, value):
+        self._num_tokens += key.shape[0]
+
+    def reset(self):
+        self._num_tokens = 0
+
+
+def _make_engine(ring_capacity, num_tokens, num_kv_heads=2, head_dim=4):
+    device = torch.device("cpu")
+    store = MockStore(num_kv_heads, head_dim, device)
+    engine = KVCaptureEngine(store, ring_capacity=ring_capacity, device=device)
+    k = torch.randn(num_tokens, num_kv_heads, head_dim, device=device)
+    v = torch.randn(num_tokens, num_kv_heads, head_dim, device=device)
+    return engine, k, v
+
+
+def test_chunked_prefill_no_data_loss():
+    engine, k, v = _make_engine(ring_capacity=8, num_tokens=12)
+    engine.ingest_prefill(k, v, 12)  # 4 -> store, 8 -> ring: total 12
+    engine.ingest_prefill(k, v, 12)  # 4 -> store, ring overflows 8, 8 -> ring
+    assert engine.total_tokens == 24  # master drops the overflow (== 16)
+
+
+def test_single_prefill_no_regression():
+    engine, k, v = _make_engine(ring_capacity=8, num_tokens=12)
+    engine.ingest_prefill(k, v, 12)
+    assert engine.total_tokens == 12
+
+
+def test_small_prefill_no_regression():
+    engine, k, v = _make_engine(ring_capacity=8, num_tokens=4)
+    engine.ingest_prefill(k, v, 4)
+    assert engine.total_tokens == 4

--- a/turboquant/capture.py
+++ b/turboquant/capture.py
@@ -168,20 +168,26 @@ class KVCaptureEngine:
         return self.total_compressed_tokens + self.total_buffered_tokens
 
     def ingest_prefill(self, key: torch.Tensor, value: torch.Tensor, num_tokens: int):
-        """Bulk-capture prefill KV into the store (bypasses ring buffer).
+        """Bulk-capture prefill KV; flush ring overflow to the store.
 
+        Mirrors ``ingest_decode`` so chunked-prefill overflow is never lost.
         key/value: (num_tokens, num_kv_heads, head_dim)
         """
         if num_tokens <= self.ring.capacity:
-            self.ring.write(key[:num_tokens], value[:num_tokens], num_tokens)
+            overflow = self.ring.write(
+                key[:num_tokens], value[:num_tokens], num_tokens
+            )
         else:
             n_compress = num_tokens - self.ring.capacity
             self.store.append_chunk(key[:n_compress], value[:n_compress])
-            self.ring.write(
+            overflow = self.ring.write(
                 key[n_compress:num_tokens],
                 value[n_compress:num_tokens],
                 self.ring.capacity,
             )
+        if overflow is not None:
+            k_over, v_over = overflow
+            self.store.append_chunk(k_over, v_over)
         self._prefill_done = True
 
     def ingest_prefill_from_paged_cache(


### PR DESCRIPTION
## Problem

`KVCaptureEngine.ingest_prefill()` in `turboquant/capture.py` calls `self.ring.write(...)` but **discards the return value**. When the ring buffer overflows during a prefill call, the overflow tokens are silently lost — never compressed or stored.

This affects vLLM's default chunked prefill (`enable_chunked_prefill=True` since vLLM 0.16). When a long prompt is split across multiple prefill forwards, the second call to `ingest_prefill` finds the ring already full from the first call. `RingBuffer.write()` correctly drains the ring and returns the overflow as a `(k, v)` tuple, but `ingest_prefill` discards it. The result is silent attention quality degradation — no error is raised, but historical KV tokens are missing from the compressed store.

## Root cause

The asymmetry between `ingest_prefill` and `ingest_decode`:

```python
# ingest_decode (CORRECT — capture.py:225-228):
overflow = self.ring.write(key[:num_tokens], value[:num_tokens], num_tokens)
if overflow is not None:
    k_over, v_over = overflow
    self.store.append_chunk(k_over, v_over)

# ingest_prefill (BUGGY — was discarding overflow):
self.ring.write(key[:num_tokens], value[:num_tokens], num_tokens)  # overflow discarded
```

## Reproduction

```python
engine = KVCaptureEngine(store, ring_capacity=8, device=torch.device('cpu'))
engine.ingest_prefill(k12, v12, 12)  # 4 to store, 8 to ring -> total 12
engine.ingest_prefill(k12, v12, 12)  # 4 to store, ring overflows 8 (DISCARDED) -> total 16
assert engine.total_tokens == 24     # FAILS: 8 tokens silently lost
```

## Fix

Mirror the existing correct pattern from `ingest_decode` — capture the overflow from `ring.write()` in both branches of `ingest_prefill` and forward it to `self.store.append_chunk()`.

## Tests

`tests/test_ingest_prefill_overflow.py` — 3 tests:
- `test_chunked_prefill_no_data_loss`: two `ingest_prefill(12)` calls with `ring_capacity=8`; asserts `total_tokens == 24` (red on master, green after fix)
- `test_single_prefill_no_regression`: single prefill, no overflow; asserts `total_tokens == 12`
- `test_small_prefill_no_regression`: small prefill within capacity; asserts `total_tokens == 4`

## Scope

Only `turboquant/capture.py` (12 lines: +9/-3) and `tests/test_ingest_prefill_overflow.py` (new, 78 lines). No changes to other modules.
